### PR TITLE
Apply gofmt

### DIFF
--- a/jaro-winkler.go
+++ b/jaro-winkler.go
@@ -20,5 +20,5 @@ func JaroWinkler(a, b string, boostThreshold float64, prefixSize int) float64 {
 		}
 	}
 
-	return j + 0.1 * prefixMatch * (1.0 - j)
+	return j + 0.1*prefixMatch*(1.0-j)
 }

--- a/jaro.go
+++ b/jaro.go
@@ -9,14 +9,14 @@ func Jaro(a, b string) float64 {
 	lb := float64(len(b))
 
 	// match range = max(len(a), len(b)) / 2 - 1
-	matchRange := int(math.Floor(math.Max(la, lb) / 2.0)) - 1
-	matchRange = int(math.Max(0, float64(matchRange - 1)))
+	matchRange := int(math.Floor(math.Max(la, lb)/2.0)) - 1
+	matchRange = int(math.Max(0, float64(matchRange-1)))
 	var matches, halfs float64
 	transposed := make([]bool, len(b))
 
 	for i := 0; i < len(a); i++ {
 		start := int(math.Max(0, float64(i-matchRange)))
-		end := int(math.Min(lb - 1, float64(i+matchRange)))
+		end := int(math.Min(lb-1, float64(i+matchRange)))
 
 		for j := start; j <= end; j++ {
 			if transposed[j] {
@@ -38,7 +38,7 @@ func Jaro(a, b string) float64 {
 		return 0
 	}
 
-	transposes := math.Floor(float64(halfs/2))
+	transposes := math.Floor(float64(halfs / 2))
 
-	return ((matches/la) + (matches/lb) + (matches-transposes)/matches) / 3.0
+	return ((matches / la) + (matches / lb) + (matches-transposes)/matches) / 3.0
 }

--- a/tests/hamming_test.go
+++ b/tests/hamming_test.go
@@ -2,8 +2,8 @@ package tests
 
 import (
 	"fmt"
-	"testing"
 	"github.com/xrash/smetrics"
+	"testing"
 )
 
 func TestHamming(t *testing.T) {

--- a/tests/jaro-winkler_test.go
+++ b/tests/jaro-winkler_test.go
@@ -1,9 +1,9 @@
 package tests
 
 import (
-	"testing"
 	"fmt"
 	"github.com/xrash/smetrics"
+	"testing"
 )
 
 func TestJaroWinkler(t *testing.T) {

--- a/tests/jaro_test.go
+++ b/tests/jaro_test.go
@@ -1,9 +1,9 @@
 package tests
 
 import (
-	"testing"
 	"fmt"
 	"github.com/xrash/smetrics"
+	"testing"
 )
 
 func TestJaro(t *testing.T) {

--- a/tests/soundex_test.go
+++ b/tests/soundex_test.go
@@ -1,9 +1,9 @@
 package tests
 
 import (
-	"testing"
 	"fmt"
 	"github.com/xrash/smetrics"
+	"testing"
 )
 
 func TestSoundex(t *testing.T) {

--- a/tests/testcases.go
+++ b/tests/testcases.go
@@ -7,12 +7,12 @@ type jarocase struct {
 }
 
 type levenshteincase struct {
-	s string
-	t string
+	s     string
+	t     string
 	icost int
 	dcost int
 	scost int
-	r int
+	r     int
 }
 
 type soundexcase struct {
@@ -21,7 +21,7 @@ type soundexcase struct {
 }
 
 type hammingcase struct {
-	a string
-	b string
+	a    string
+	b    string
 	diff int
 }

--- a/tests/ukkonen_test.go
+++ b/tests/ukkonen_test.go
@@ -1,9 +1,9 @@
 package tests
 
 import (
-	"testing"
 	"fmt"
 	"github.com/xrash/smetrics"
+	"testing"
 )
 
 func TestUkkonen(t *testing.T) {

--- a/tests/wagner-fischer_test.go
+++ b/tests/wagner-fischer_test.go
@@ -1,9 +1,9 @@
 package tests
 
 import (
-	"testing"
 	"fmt"
 	"github.com/xrash/smetrics"
+	"testing"
 )
 
 func TestWagnerFischer(t *testing.T) {

--- a/ukkonen.go
+++ b/ukkonen.go
@@ -9,13 +9,13 @@ func Ukkonen(a, b string, icost, dcost, scost int) int {
 
 	if icost < dcost && icost < scost {
 		lowerCost = icost
-	} else if (dcost < scost) {
+	} else if dcost < scost {
 		lowerCost = dcost
 	} else {
 		lowerCost = scost
 	}
 
-	infinite := math.MaxInt32/2
+	infinite := math.MaxInt32 / 2
 
 	if len(a) > len(b) {
 		tmp := b
@@ -30,24 +30,24 @@ func Ukkonen(a, b string, icost, dcost, scost int) int {
 	t := (len(b) - len(a) + 1) * lowerCost
 
 	for {
-		if (t/lowerCost) < (len(b) - len(a)) {
+		if (t / lowerCost) < (len(b) - len(a)) {
 			continue
 		}
 
-		// This is the right damn thing since the original Ukkonen 
+		// This is the right damn thing since the original Ukkonen
 		// paper minimizes the expression result only, but the uncommented version
 		// doesn't need to deal with floats so it's faster.
 		// p = int(math.Floor(0.5*((float64(t)/float64(lowerCost)) - float64(len(b) - len(a)))))
-		p = ((t/lowerCost) - (len(b) - len(a))) / 2
+		p = ((t / lowerCost) - (len(b) - len(a))) / 2
 
 		k = -p
 		kprime = k
 
-		rowlength := (len(b) - len(a)) + (2*p)
+		rowlength := (len(b) - len(a)) + (2 * p)
 
-		r = make([]int, rowlength + 2)
+		r = make([]int, rowlength+2)
 
-		for i := 0; i < rowlength + 2; i++ {
+		for i := 0; i < rowlength+2; i++ {
 			r[i] = infinite
 		}
 
@@ -56,7 +56,7 @@ func Ukkonen(a, b string, icost, dcost, scost int) int {
 				if i == j+k && i == 0 {
 					r[j] = 0
 				} else {
-					if (j-1 < 0) {
+					if j-1 < 0 {
 						ins = infinite
 					} else {
 						ins = r[j-1] + icost
@@ -73,7 +73,7 @@ func Ukkonen(a, b string, icost, dcost, scost int) int {
 
 					if ins < del && ins < sub {
 						r[j] = ins
-					} else if (del < sub) {
+					} else if del < sub {
 						r[j] = del
 					} else {
 						r[j] = sub
@@ -83,12 +83,12 @@ func Ukkonen(a, b string, icost, dcost, scost int) int {
 			k++
 		}
 
-		if r[(len(b) - len(a)) + (2 * p) + kprime] <= t {
-			break;
+		if r[(len(b)-len(a))+(2*p)+kprime] <= t {
+			break
 		} else {
 			t *= 2
 		}
 	}
 
-	return r[(len(b) - len(a)) + (2 * p) + kprime]
+	return r[(len(b)-len(a))+(2*p)+kprime]
 }

--- a/wagner-fischer.go
+++ b/wagner-fischer.go
@@ -13,15 +13,15 @@ func WagnerFischer(a, b string, icost, dcost, scost int) int {
 	// Compute the lower of the insert, deletion and substitution costs.
 	if icost < dcost && icost < scost {
 		lowerCost = icost
-	} else if (dcost < scost) {
+	} else if dcost < scost {
 		lowerCost = dcost
 	} else {
 		lowerCost = scost
 	}
 
 	// Allocate the array that will hold the last row.
-	row1 := make([]int, len(a) + 1)
-	row2 := make([]int, len(a) + 1)
+	row1 := make([]int, len(a)+1)
+	row2 := make([]int, len(a)+1)
 	var tmp []int
 
 	// Initialize the arrays.
@@ -44,7 +44,7 @@ func WagnerFischer(a, b string, icost, dcost, scost int) int {
 
 				if ins < del && ins < sub {
 					row2[j] = ins
-				} else if (del < sub) {
+				} else if del < sub {
 					row2[j] = del
 				} else {
 					row2[j] = sub
@@ -59,5 +59,5 @@ func WagnerFischer(a, b string, icost, dcost, scost int) int {
 	}
 
 	// Because we swapped the rows, the final result is in row1 instead of row2.
-	return row1[len(row1) - 1]
+	return row1[len(row1)-1]
 }


### PR DESCRIPTION
This is the result of applying `gofmt -w .` to the root of the repository.
 
I just noticed these files weren't [gofmt] formatted when linting my own code where this is vendored. Most Go code is formatted this way, which is nice because it avoids having to use any thought about formatting, and avoids needless formatting diffs.

[gofmt]: https://golang.org/cmd/gofmt/ 