### PR TITLE
Soundex: Performance Optimizations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,0 @@
-module github.com/xrash/smetrics
-
-go 1.21.1

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/xrash/smetrics
+
+go 1.21.1

--- a/soundex.go
+++ b/soundex.go
@@ -6,36 +6,53 @@ import (
 
 // The Soundex encoding. It is a phonetic algorithm that considers how the words sound in English. Soundex maps a string to a 4-byte code consisting of the first letter of the original string and three numbers. Strings that sound similar should map to the same code.
 func Soundex(s string) string {
-	m := map[byte]string{
-		'B': "1", 'P': "1", 'F': "1", 'V': "1",
-		'C': "2", 'S': "2", 'K': "2", 'G': "2", 'J': "2", 'Q': "2", 'X': "2", 'Z': "2",
-		'D': "3", 'T': "3",
-		'L': "4",
-		'M': "5", 'N': "5",
-		'R': "6",
-	}
-
-	s = strings.ToUpper(s)
-
-	r := string(s[0])
+	b := strings.Builder{}
+	b.Grow(4)
+	b.WriteByte(s[0])
 	p := s[0]
-	for i := 1; i < len(s) && len(r) < 4; i++ {
+	n := 0
+	for i := 1; i < len(s); i++ {
 		c := s[i]
 
-		if (c < 'A' || c > 'Z') || (c == p) {
+		if c <= 'z' && c >= 'a' {
+			c -= 32 // convert to uppercase
+		} else if c < 'A' || c > 'Z' {
+			continue
+		}
+
+		if c == p {
 			continue
 		}
 
 		p = c
 
-		if n, ok := m[c]; ok {
-			r += n
+		switch c {
+		case 'B', 'P', 'F', 'V':
+			c = '1'
+		case 'C', 'S', 'K', 'G', 'J', 'Q', 'X', 'Z':
+			c = '2'
+		case 'D', 'T':
+			c = '3'
+		case 'L':
+			c = '4'
+		case 'M', 'N':
+			c = '5'
+		case 'R':
+			c = '6'
+		default:
+			continue
+		}
+
+		b.WriteByte(c)
+		n++
+		if n == 3 {
+			break
 		}
 	}
 
-	for i := len(r); i < 4; i++ {
-		r += "0"
+	for i := n; i < 3; i++ {
+		b.WriteByte('0')
 	}
 
-	return r
+	return b.String()
 }

--- a/soundex.go
+++ b/soundex.go
@@ -13,10 +13,6 @@ func Soundex(s string) string {
 	if p <= 'z' && p >= 'a' {
 		p -= 32 // convert to uppercase
 	}
-	if p < 'A' || p > 'Z' {
-		// invalid first letter
-		return "0000"
-	}
 	b.WriteByte(p)
 
 	n := 0

--- a/soundex.go
+++ b/soundex.go
@@ -8,8 +8,17 @@ import (
 func Soundex(s string) string {
 	b := strings.Builder{}
 	b.Grow(4)
-	b.WriteByte(s[0])
+
 	p := s[0]
+	if p <= 'z' && p >= 'a' {
+		p -= 32 // convert to uppercase
+	}
+	if p < 'A' || p > 'Z' {
+		// invalid first letter
+		return "0000"
+	}
+	b.WriteByte(p)
+
 	n := 0
 	for i := 1; i < len(s); i++ {
 		c := s[i]

--- a/tests/soundex_test.go
+++ b/tests/soundex_test.go
@@ -6,24 +6,6 @@ import (
 	"testing"
 )
 
-//func BenchmarkSoundex(b *testing.B) {
-//	fd, err := os.Open("testdata/english_names.txt")
-//	if err != nil {
-//		b.Fatal(err)
-//	}
-//	defer fd.Close()
-//
-//	scanner := bufio.NewScanner(fd)
-//	for scanner.Scan() {
-//		s := smetrics.Soundex(scanner.Text())
-//
-//		// Trivially use the result to avoid compiler optimizations.
-//		if len(s) != 4 {
-//			b.Fail()
-//		}
-//	}
-//}
-
 func TestSoundex(t *testing.T) {
 	cases := []soundexcase{
 		{"Euler", "E460"},

--- a/tests/soundex_test.go
+++ b/tests/soundex_test.go
@@ -6,6 +6,24 @@ import (
 	"testing"
 )
 
+//func BenchmarkSoundex(b *testing.B) {
+//	fd, err := os.Open("testdata/english_names.txt")
+//	if err != nil {
+//		b.Fatal(err)
+//	}
+//	defer fd.Close()
+//
+//	scanner := bufio.NewScanner(fd)
+//	for scanner.Scan() {
+//		s := smetrics.Soundex(scanner.Text())
+//
+//		// Trivially use the result to avoid compiler optimizations.
+//		if len(s) != 4 {
+//			b.Fail()
+//		}
+//	}
+//}
+
 func TestSoundex(t *testing.T) {
 	cases := []soundexcase{
 		{"Euler", "E460"},
@@ -26,7 +44,7 @@ func TestSoundex(t *testing.T) {
 
 	for _, c := range cases {
 		if r := smetrics.Soundex(c.s); r != c.t {
-			fmt.Println(r, "instead of", c.t)
+			fmt.Println(r, "instead of", c.t, "for", c.s)
 			t.Fail()
 		}
 	}


### PR DESCRIPTION
Hello!

I have optimized the soundex function's cpu performance by a little over 10x.

| Current | This PR |
| --- | --- |
| `0.3875 ns/op` | `0.03767 ns/op` |

At your convenience and discretion, please pull the following changes:

Project:
1.  Created a go.mod file to allow use of `go test` at the project level

Soundex:
1. Removed map and replaced with a `switch case` statement for performance, which avoids allocations and map access latency.
2. Switched all letter variables to bytes, since this function only supports ASCII anyway.
3. Removed all function calls in the inner loop. (`toUpper` was especially slow)
4. Used a stringbuilder so that only a single allocation is made per iteration.
5. I have included the bechmark code I used. This was tested against 500k randomly generated english names. I am not including the test set, so I have commented out the benchmark.