### PR TITLE
Use only minor version in go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/xrash/smetrics
 
-go 1.15.0
+go 1.15


### PR DESCRIPTION
This change removes the patch version specifier from the go version in the go.mod file.

See https://go.dev/ref/mod#go-mod-file-go