### PR TITLE
fix(jaro): correct transpositions calculation by moving float conversion before division

### DIFF
--- a/jaro.go
+++ b/jaro.go
@@ -75,7 +75,7 @@ func Jaro(a, b string) float64 {
 	}
 
 	// The number of unaligned matches divided by two, is the number of _transpositions_.
-	transpositions := math.Floor(float64(unaligned / 2))
+	transpositions := math.Floor(float64(unaligned) / 2)
 
 	// Jaro distance is the average between these three numbers:
 	// 1. matches / length of string A


### PR DESCRIPTION
Previously, math.Floor was applied to the result of an integer division (unaligned / 2), which always produced an integer and made math.Floor redundant

```go
math.Floor(float64(unaligned / 2)) //  note that (unaligned / 2) is a integer
// calling math.Floor on a converted integer is pointless
```

Now, math.Floor(float64(unaligned)/2) is used to properly round down after floating point division.