### PR TITLE
Add Metaphone phonetic encoding algorithm

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -14,6 +14,8 @@ Jaro() and JaroWinkler(). Read the documentation on these functions.
 
 For the Soundex algorithm, check the function Soundex().
 
+For the Metaphone algorithm, check the function Metaphone().
+
 For the Hamming distance algorithm, check the function Hamming().
 */
 package smetrics

--- a/metaphone.go
+++ b/metaphone.go
@@ -1,0 +1,252 @@
+package smetrics
+
+import (
+	"strings"
+)
+
+// Metaphone computes the Metaphone phonetic encoding of the given string.
+// It is a phonetic algorithm that produces a code representing the English
+// pronunciation of a word. Words that sound similar should produce the same code.
+// The algorithm was published by Lawrence Philips in "Hanging on the Metaphone",
+// Computer Language, Vol. 7, No. 12, December 1990.
+//
+// Unlike some implementations that truncate to 4 or 6 characters, this function
+// returns the full encoding. Callers can truncate the result if needed.
+func Metaphone(s string) string {
+	if len(s) == 0 {
+		return ""
+	}
+
+	// Filter to letters only and convert to uppercase.
+	chars := filterLetters(s)
+	n := len(chars)
+	if n == 0 {
+		return ""
+	}
+	if n == 1 {
+		return string(chars)
+	}
+
+	// Transform first characters.
+	chars = transformFirst(chars)
+	n = len(chars)
+
+	b := strings.Builder{}
+	b.Grow(n)
+
+	for i := 0; i < n; i++ {
+		c := chars[i]
+
+		// Skip duplicate consecutive characters (except C).
+		if c != 'C' && i > 0 && chars[i-1] == c {
+			continue
+		}
+
+		switch c {
+		case 'A', 'E', 'I', 'O', 'U':
+			// Vowels are only kept at the beginning.
+			if i == 0 {
+				b.WriteByte(c)
+			}
+
+		case 'B':
+			// B is silent in final MB.
+			if !(i == n-1 && i > 0 && chars[i-1] == 'M') {
+				b.WriteByte('B')
+			}
+
+		case 'C':
+			if i > 0 && chars[i-1] == 'S' && i+1 < n && isFrontvByte(chars[i+1]) {
+				// SCI, SCE, SCY — C is silent.
+				continue
+			}
+			if i > 0 && chars[i-1] == 'S' && i+1 < n && chars[i+1] == 'H' {
+				// SCH → SK
+				b.WriteByte('K')
+			} else if (i+1 < n && chars[i+1] == 'H') || (i+2 < n && chars[i+1] == 'I' && chars[i+2] == 'A') {
+				// CIA or CH → X
+				b.WriteByte('X')
+			} else if i+1 < n && isFrontvByte(chars[i+1]) {
+				// CI, CE, CY → S
+				b.WriteByte('S')
+			} else {
+				b.WriteByte('K')
+			}
+
+		case 'D':
+			if i+2 < n && chars[i+1] == 'G' && isFrontvByte(chars[i+2]) {
+				// DGE, DGI, DGY → J
+				b.WriteByte('J')
+				i += 2
+			} else {
+				b.WriteByte('T')
+			}
+
+		case 'F':
+			b.WriteByte('F')
+
+		case 'G':
+			// GH at end or before consonant → silent.
+			if i+1 < n && chars[i+1] == 'H' {
+				if i+1 == n-1 || !isVowelByte(chars[i+2]) {
+					continue
+				}
+			}
+			// GN not at start → silent G.
+			if i > 0 && i+1 < n && chars[i+1] == 'N' {
+				continue
+			}
+			if i+1 < n && isFrontvByte(chars[i+1]) {
+				b.WriteByte('J')
+			} else {
+				b.WriteByte('K')
+			}
+
+		case 'H':
+			// H is silent at end, after varson chars (C, S, P, T, G), or
+			// before a consonant. Digraph handlers (SH, PH, TH, CH) don't
+			// advance past the H; instead this rule silences it because
+			// the leading consonant is always in the varson set.
+			if i == n-1 {
+				continue
+			}
+			if i > 0 && isVarsonByte(chars[i-1]) {
+				continue
+			}
+			if isVowelByte(chars[i+1]) {
+				b.WriteByte('H')
+			}
+
+		case 'J':
+			b.WriteByte('J')
+
+		case 'K':
+			// K after C is silent.
+			if i > 0 && chars[i-1] == 'C' {
+				continue
+			}
+			b.WriteByte('K')
+
+		case 'L':
+			b.WriteByte('L')
+
+		case 'M':
+			b.WriteByte('M')
+
+		case 'N':
+			b.WriteByte('N')
+
+		case 'P':
+			if i+1 < n && chars[i+1] == 'H' {
+				b.WriteByte('F')
+			} else {
+				b.WriteByte('P')
+			}
+
+		case 'Q':
+			b.WriteByte('K')
+
+		case 'R':
+			b.WriteByte('R')
+
+		case 'S':
+			if i+1 < n && chars[i+1] == 'H' {
+				b.WriteByte('X')
+			} else if i+2 < n && chars[i+1] == 'I' && (chars[i+2] == 'O' || chars[i+2] == 'A') {
+				b.WriteByte('X')
+			} else {
+				b.WriteByte('S')
+			}
+
+		case 'T':
+			if i+2 < n && chars[i+1] == 'I' && (chars[i+2] == 'A' || chars[i+2] == 'O') {
+				b.WriteByte('X')
+			} else if i+2 < n && chars[i+1] == 'C' && chars[i+2] == 'H' {
+				// TCH — T is silent.
+				continue
+			} else if i+1 < n && chars[i+1] == 'H' {
+				b.WriteByte('0') // theta
+			} else {
+				b.WriteByte('T')
+			}
+
+		case 'V':
+			b.WriteByte('F')
+
+		case 'W':
+			if i+1 < n && isVowelByte(chars[i+1]) {
+				b.WriteByte('W')
+			}
+
+		case 'X':
+			b.WriteByte('K')
+			b.WriteByte('S')
+
+		case 'Y':
+			if i+1 < n && isVowelByte(chars[i+1]) {
+				b.WriteByte('Y')
+			}
+
+		case 'Z':
+			b.WriteByte('S')
+		}
+	}
+
+	return b.String()
+}
+
+// filterLetters removes non-letter characters and converts to uppercase.
+func filterLetters(s string) []byte {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'a' && c <= 'z' {
+			out = append(out, c-32)
+		} else if c >= 'A' && c <= 'Z' {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// transformFirst applies first-character transformations per the original algorithm:
+// KN, GN, PN → drop first letter; AE → drop A; WR → drop W; WH → drop H; X → S.
+func transformFirst(s []byte) []byte {
+	if len(s) < 2 {
+		return s
+	}
+	switch s[0] {
+	case 'K', 'G', 'P':
+		if s[1] == 'N' {
+			return s[1:]
+		}
+	case 'A':
+		if s[1] == 'E' {
+			return s[1:]
+		}
+	case 'W':
+		if s[1] == 'R' {
+			return s[1:]
+		}
+		if s[1] == 'H' {
+			// WH → W: drop the H.
+			copy(s[1:], s[2:])
+			return s[:len(s)-1]
+		}
+	case 'X':
+		s[0] = 'S'
+	}
+	return s
+}
+
+func isVowelByte(c byte) bool {
+	return c == 'A' || c == 'E' || c == 'I' || c == 'O' || c == 'U'
+}
+
+func isFrontvByte(c byte) bool {
+	return c == 'E' || c == 'I' || c == 'Y'
+}
+
+func isVarsonByte(c byte) bool {
+	return c == 'C' || c == 'S' || c == 'P' || c == 'T' || c == 'G'
+}

--- a/metaphone.go
+++ b/metaphone.go
@@ -1,9 +1,5 @@
 package smetrics
 
-import (
-	"strings"
-)
-
 // Metaphone computes the Metaphone phonetic encoding of the given string.
 // It is a phonetic algorithm that produces a code representing the English
 // pronunciation of a word. Words that sound similar should produce the same code.
@@ -19,20 +15,18 @@ func Metaphone(s string) string {
 
 	// Filter to letters only and convert to uppercase.
 	chars := filterLetters(s)
-	n := len(chars)
-	if n == 0 {
+	if len(chars) == 0 {
 		return ""
-	}
-	if n == 1 {
-		return string(chars)
 	}
 
 	// Transform first characters.
 	chars = transformFirst(chars)
-	n = len(chars)
+	n := len(chars)
+	if n == 1 {
+		return string(chars)
+	}
 
-	b := strings.Builder{}
-	b.Grow(n)
+	result := make([]byte, 0, n)
 
 	for i := 0; i < n; i++ {
 		c := chars[i]
@@ -46,13 +40,13 @@ func Metaphone(s string) string {
 		case 'A', 'E', 'I', 'O', 'U':
 			// Vowels are only kept at the beginning.
 			if i == 0 {
-				b.WriteByte(c)
+				result = append(result, c)
 			}
 
 		case 'B':
 			// B is silent in final MB.
 			if !(i == n-1 && i > 0 && chars[i-1] == 'M') {
-				b.WriteByte('B')
+				result = append(result, 'B')
 			}
 
 		case 'C':
@@ -62,28 +56,28 @@ func Metaphone(s string) string {
 			}
 			if i > 0 && chars[i-1] == 'S' && i+1 < n && chars[i+1] == 'H' {
 				// SCH → SK
-				b.WriteByte('K')
+				result = append(result, 'K')
 			} else if (i+1 < n && chars[i+1] == 'H') || (i+2 < n && chars[i+1] == 'I' && chars[i+2] == 'A') {
 				// CIA or CH → X
-				b.WriteByte('X')
+				result = append(result, 'X')
 			} else if i+1 < n && isFrontvByte(chars[i+1]) {
 				// CI, CE, CY → S
-				b.WriteByte('S')
+				result = append(result, 'S')
 			} else {
-				b.WriteByte('K')
+				result = append(result, 'K')
 			}
 
 		case 'D':
 			if i+2 < n && chars[i+1] == 'G' && isFrontvByte(chars[i+2]) {
 				// DGE, DGI, DGY → J
-				b.WriteByte('J')
+				result = append(result, 'J')
 				i += 2
 			} else {
-				b.WriteByte('T')
+				result = append(result, 'T')
 			}
 
 		case 'F':
-			b.WriteByte('F')
+			result = append(result, 'F')
 
 		case 'G':
 			// GH at end or before consonant → silent.
@@ -97,9 +91,9 @@ func Metaphone(s string) string {
 				continue
 			}
 			if i+1 < n && isFrontvByte(chars[i+1]) {
-				b.WriteByte('J')
+				result = append(result, 'J')
 			} else {
-				b.WriteByte('K')
+				result = append(result, 'K')
 			}
 
 		case 'H':
@@ -114,96 +108,106 @@ func Metaphone(s string) string {
 				continue
 			}
 			if isVowelByte(chars[i+1]) {
-				b.WriteByte('H')
+				result = append(result, 'H')
 			}
 
 		case 'J':
-			b.WriteByte('J')
+			result = append(result, 'J')
 
 		case 'K':
 			// K after C is silent.
 			if i > 0 && chars[i-1] == 'C' {
 				continue
 			}
-			b.WriteByte('K')
+			result = append(result, 'K')
 
 		case 'L':
-			b.WriteByte('L')
+			result = append(result, 'L')
 
 		case 'M':
-			b.WriteByte('M')
+			result = append(result, 'M')
 
 		case 'N':
-			b.WriteByte('N')
+			result = append(result, 'N')
 
 		case 'P':
 			if i+1 < n && chars[i+1] == 'H' {
-				b.WriteByte('F')
+				result = append(result, 'F')
 			} else {
-				b.WriteByte('P')
+				result = append(result, 'P')
 			}
 
 		case 'Q':
-			b.WriteByte('K')
+			result = append(result, 'K')
 
 		case 'R':
-			b.WriteByte('R')
+			result = append(result, 'R')
 
 		case 'S':
 			if i+1 < n && chars[i+1] == 'H' {
-				b.WriteByte('X')
+				result = append(result, 'X')
 			} else if i+2 < n && chars[i+1] == 'I' && (chars[i+2] == 'O' || chars[i+2] == 'A') {
-				b.WriteByte('X')
+				result = append(result, 'X')
 			} else {
-				b.WriteByte('S')
+				result = append(result, 'S')
 			}
 
 		case 'T':
 			if i+2 < n && chars[i+1] == 'I' && (chars[i+2] == 'A' || chars[i+2] == 'O') {
-				b.WriteByte('X')
+				result = append(result, 'X')
 			} else if i+2 < n && chars[i+1] == 'C' && chars[i+2] == 'H' {
 				// TCH — T is silent.
 				continue
 			} else if i+1 < n && chars[i+1] == 'H' {
-				b.WriteByte('0') // theta
+				result = append(result, '0') // theta
 			} else {
-				b.WriteByte('T')
+				result = append(result, 'T')
 			}
 
 		case 'V':
-			b.WriteByte('F')
+			result = append(result, 'F')
 
 		case 'W':
 			if i+1 < n && isVowelByte(chars[i+1]) {
-				b.WriteByte('W')
+				result = append(result, 'W')
 			}
 
 		case 'X':
-			b.WriteByte('K')
-			b.WriteByte('S')
+			result = append(result, 'K')
+			result = append(result, 'S')
 
 		case 'Y':
 			if i+1 < n && isVowelByte(chars[i+1]) {
-				b.WriteByte('Y')
+				result = append(result, 'Y')
 			}
 
 		case 'Z':
-			b.WriteByte('S')
+			result = append(result, 'S')
 		}
 	}
 
-	return b.String()
+	return string(result)
 }
 
 // filterLetters removes non-letter characters and converts to uppercase.
 func filterLetters(s string) []byte {
-	out := make([]byte, 0, len(s))
+	count := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') {
+			count++
+		}
+	}
+	out := make([]byte, count)
+	j := 0
 	for i := 0; i < len(s); i++ {
 		c := s[i]
 		if c >= 'a' && c <= 'z' {
-			out = append(out, c-32)
+			out[j] = c - 32
+			j++
 		} else if c >= 'A' && c <= 'Z' {
-			out = append(out, c)
+			out[j] = c
+			j++
 		}
 	}
 	return out
@@ -212,6 +216,12 @@ func filterLetters(s string) []byte {
 // transformFirst applies first-character transformations per the original algorithm:
 // KN, GN, PN → drop first letter; AE → drop A; WR → drop W; WH → drop H; X → S.
 func transformFirst(s []byte) []byte {
+	if len(s) == 1 {
+		if s[0] == 'X' {
+			s[0] = 'S'
+		}
+		return s
+	}
 	if len(s) < 2 {
 		return s
 	}

--- a/tests/metaphone_test.go
+++ b/tests/metaphone_test.go
@@ -2,8 +2,9 @@ package tests
 
 import (
 	"fmt"
-	"github.com/xrash/smetrics"
 	"testing"
+
+	"github.com/xrash/smetrics"
 )
 
 func TestMetaphone(t *testing.T) {
@@ -46,19 +47,19 @@ func TestMetaphone(t *testing.T) {
 		{"Incomprehensibility", "INKMPRHNSBLT"},
 
 		// Initial character transforms.
-		{"knight", "NT"},  // KN → N
-		{"gnome", "NM"},   // GN → N
-		{"pneumatic", "NMTK"}, // PN → N
+		{"knight", "NT"},       // KN → N
+		{"gnome", "NM"},        // GN → N
+		{"pneumatic", "NMTK"},  // PN → N
 		{"aesthetic", "ES0TK"}, // AE → E
-		{"wrong", "RNK"},  // WR → R
+		{"wrong", "RNK"},       // WR → R
 
 		// Silent letters and digraphs.
-		{"lamb", "LM"},    // silent B after M at end
-		{"phone", "FN"},   // PH → F
-		{"ship", "XP"},    // SH → X
-		{"thick", "0K"},   // TH → 0 (theta)
-		{"match", "MX"},   // TCH → silent T, CH → X
-		{"edge", "EJ"},    // DGE → J
+		{"lamb", "LM"},  // silent B after M at end
+		{"phone", "FN"}, // PH → F
+		{"ship", "XP"},  // SH → X
+		{"thick", "0K"}, // TH → 0 (theta)
+		{"match", "MX"}, // TCH → silent T, CH → X
+		{"edge", "EJ"},  // DGE → J
 
 		// CH always maps to X per original algorithm.
 		{"church", "XRX"},
@@ -72,17 +73,129 @@ func TestMetaphone(t *testing.T) {
 		{"ghost", "KST"},
 
 		// WH → W at start.
-		{"wh", ""},
+		{"wh", "W"},
 		{"whistle", "WSTL"},
 
 		// GN silences G at any non-initial position (per original algorithm).
 		{"signal", "SNL"},
+
+		// Additional test cases
+		{"programming", "PRKRMNK"},
+		{"programmer", "PRKRMR"},
+		{"Asterix", "ASTRKS"},
+		{"Plaçe", "PL"}, // ç ignored, P L A E → P L
+		{"Place", "PLS"},
+		{"aebersold", "EBRSLT"}, // AE → E
+		{"gnagy", "NJ"},         // GN → N, G before Y → J
+		{"knuth", "N0"},         // KN → N, TH → 0
+		{"pniewski", "NSK"},     // PN → N
+		{"wright", "RT"},        // WR → R
+		{"deng", "TNK"},         // D T, N N, G K
+		{"xiaopeng", "XPNK"},    // S I A → X, P N K
+		{"whalen", "WLN"},       // WH→W
+		{"dumb", "TM"},          // B silent after M at end
+		{"mccomb", "MKKM"},      // CC → K K, B silent
+		{"cia", "X"},            // CIA → X
+		{"ch", "X"},             // CH → X
+		{"ci", "S"},             // CI → S
+		{"ce", "S"},             // CE → S
+		{"cy", "S"},             // CY → S
+		{"sci", "S"},            // S I → S, C silent
+		{"sce", "S"},            // S E → S, C silent
+		{"scy", "S"},            // S Y → S, C silent
+		{"sch", "SK"},           // SCH → SK
+		{"dge", "J"},            // DGE → J
+		{"dgy", "J"},            // DGY → J
+		{"dgi", "J"},            // DGI → J
+		{"gh", ""},              // GH silent at end
+		{"gn", "N"},             // GN at start → N
+		{"gned", "NT"},          // GNED → N T (G silent, NED → N E D → N T)
+		{"gg", "K"},             // GG → K (not J)
+		{"ck", "K"},             // CK → K
+		{"ph", "F"},             // PH → F
+		{"sh", "X"},             // SH → X
+		{"sio", "X"},            // SIO → X
+		{"sia", "X"},            // SIA → X
+		{"tia", "X"},            // TIA → X
+		{"tio", "X"},            // TIO → X
+		{"th", "0"},             // TH → 0
+		{"tch", "X"},            // T silent, C H → X
+		{"v", "V"},              // Single letter
+		{"w", "W"},              // Single letter
+		{"wa", "W"},             // W followed by vowel
+		{"x", "S"},              // Single letter, initial X → S
+		{"y", "Y"},              // Single letter
+		{"ya", "Y"},             // Y followed by vowel
+		{"z", "Z"},              // Single letter
+
+		// Additional edge cases for completeness
+		{"scuba", "SKB"},      // SCUBA → S K U B A → S K B
+		{"scissors", "SSRS"},  // SCISSORS → S C I S S O R S → S S R S
+		{"queue", "K"},        // QUEUE → K U E U E → K
+		{"rhythm", "R0M"},     // RHYTHM → R H Y T H M → R 0 M
+		{"aaa", "A"},          // Duplicate vowels at start
+		{"xyz", "SS"},         // X Y Z → S S
+		{"123science", "SNS"}, // Non-letters ignored
+		{"a1b2c", "ABK"},      // Mixed non-letters
+
+		// Edge cases.
+		{"aeiou", "E"},             // AE → E, then vowels dropped
+		{"bcdfg", "BKTFK"},         // B K T F K
+		{"hijklmnop", "HJKLMNP"},   // H J K L M N P
+		{"qrstuvwxyz", "KRSTFKSS"}, // K R S T F K S S
 	}
 
 	for _, c := range cases {
 		if r := smetrics.Metaphone(c.s); r != c.t {
 			fmt.Println(r, "instead of", c.t, "for", c.s)
 			t.Fail()
+		}
+	}
+}
+
+func BenchmarkMetaphone(b *testing.B) {
+	testCases := []string{
+		"programming",
+		"metaphone",
+		"incomprehensibility",
+		"pneumatic",
+		"knight",
+		"wrong",
+		"whistle",
+		"signal",
+		"asterix",
+		"aebersold",
+		"dengxiaopeng",
+		"mccomb",
+		"church",
+		"ghost",
+		"edge",
+		"thick",
+		"phone",
+		"ship",
+		"lamb",
+		"zen",
+		"vowel",
+		"xerox",
+		"queen",
+		"jack",
+		"dodge",
+		"dumb",
+		"science",
+		"orange",
+		"tech",
+		"garbage",
+		"metaphone",
+		"david",
+		"campbel",
+		"zach",
+		"donald",
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, s := range testCases {
+			smetrics.Metaphone(s)
 		}
 	}
 }

--- a/tests/metaphone_test.go
+++ b/tests/metaphone_test.go
@@ -1,0 +1,88 @@
+package tests
+
+import (
+	"fmt"
+	"github.com/xrash/smetrics"
+	"testing"
+)
+
+func TestMetaphone(t *testing.T) {
+	cases := []metaphonecase{
+		// Empty and single character.
+		{"", ""},
+		{"A", "A"},
+		{"a", "A"},
+		{"B", "B"},
+
+		// Non-letter input.
+		{"123", ""},
+		{"a1b", "AB"},
+
+		// Common words.
+		{"Donald", "TNLT"},
+		{"Zach", "SX"},
+		{"Campbel", "KMPBL"},
+		{"David", "TFT"},
+		{"Metaphone", "MTFN"},
+		{"garbage", "KRBJ"},
+		{"tech", "TX"},
+		{"orange", "ORNJ"},
+		{"science", "SNS"},
+		{"dumb", "TM"},
+		{"dodge", "TJ"},
+		{"jack", "JK"},
+		{"queen", "KN"},
+		{"widow", "WT"},
+		{"xerox", "SRKS"},
+		{"vowel", "FWL"},
+		{"zen", "SN"},
+		{"tiamat", "XMT"},
+		{"ratio", "RX"},
+		{"the", "0"},
+		{"acacia", "AKX"},
+		{"bosch", "BSK"},
+		{"chop", "XP"},
+		{"hatch", "HX"},
+		{"Incomprehensibility", "INKMPRHNSBLT"},
+
+		// Initial character transforms.
+		{"knight", "NT"},  // KN → N
+		{"gnome", "NM"},   // GN → N
+		{"pneumatic", "NMTK"}, // PN → N
+		{"aesthetic", "ES0TK"}, // AE → E
+		{"wrong", "RNK"},  // WR → R
+
+		// Silent letters and digraphs.
+		{"lamb", "LM"},    // silent B after M at end
+		{"phone", "FN"},   // PH → F
+		{"ship", "XP"},    // SH → X
+		{"thick", "0K"},   // TH → 0 (theta)
+		{"match", "MX"},   // TCH → silent T, CH → X
+		{"edge", "EJ"},    // DGE → J
+
+		// CH always maps to X per original algorithm.
+		{"church", "XRX"},
+		{"chess", "XS"},
+
+		// Full output without truncation.
+		{"crying", "KRYNK"},
+
+		// GH silent at end and before consonant.
+		{"weigh", "W"},
+		{"ghost", "KST"},
+
+		// WH → W at start.
+		{"wh", ""},
+		{"whistle", "WSTL"},
+
+		// GN silences G at any non-initial position (per original algorithm).
+		{"signal", "SNL"},
+	}
+
+	for _, c := range cases {
+		if r := smetrics.Metaphone(c.s); r != c.t {
+			fmt.Println(r, "instead of", c.t, "for", c.s)
+			t.Fail()
+		}
+	}
+}

--- a/tests/testcases.go
+++ b/tests/testcases.go
@@ -14,6 +14,11 @@ type soundexcase struct {
 	t string
 }
 
+type metaphonecase struct {
+	s string
+	t string
+}
+
 type hammingcase struct {
 	a    string
 	b    string


### PR DESCRIPTION
Adds a `Metaphone(s string) string` function implementing the original Lawrence Philips Metaphone algorithm ("Hanging on the Metaphone", *Computer Language*, Dec. 1990).

Metaphone complements Soundex by applying English pronunciation rules for more accurate phonetic matching, for example, "phone" and "fone" produce the same code.

All existing tests pass.